### PR TITLE
Refactored Version Numbers

### DIFF
--- a/TVRename#/App/Version.cs
+++ b/TVRename#/App/Version.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Main website for TVRename is http://tvrename.com
 // 
 // Source code available at http://code.google.com/p/tvrename/
@@ -7,6 +7,8 @@
 // 
 
 using System;
+using System.Linq;
+using System.Reflection;
 
 namespace TVRename
 {
@@ -19,7 +21,7 @@ namespace TVRename
         public static bool OnMono()
         {
             if (!OnMonoCached.HasValue)
-                OnMonoCached = System.Type.GetType("Mono.Runtime") != null;
+                OnMonoCached = Type.GetType("Mono.Runtime") != null;
             return OnMonoCached.Value;
         }
 
@@ -51,9 +53,7 @@ namespace TVRename
             // Version 2.2.0b2 released 14 April 2010, r108
             // Version 2.2.0b1 released 9 April 2010, r94
 
-	        System.Version version = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
-	        string v = $"{version.Major}.{version.Minor}.{version.Build}";
-	        if (version.Revision > 0) v += "." + version.Revision;
+            string v = Assembly.GetExecutingAssembly().GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false).Cast<AssemblyInformationalVersionAttribute>().First().InformationalVersion;
 #if DEBUG
             v += " ** Debug Build **";
 #endif

--- a/TVRename#/Properties/AssemblyInfo.cs
+++ b/TVRename#/Properties/AssemblyInfo.cs
@@ -8,8 +8,8 @@ using System.Resources;
 [assembly: AssemblyTitle("TV Rename")]
 [assembly: AssemblyDescription("TV Rename")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("TVRename")] // used in settings path, so be careful about changing
-[assembly: AssemblyProduct("TVRename")] // used in settings path, so be careful about changing
+[assembly: AssemblyCompany("TV Rename")]
+[assembly: AssemblyProduct("TV Rename")]
 [assembly: AssemblyCopyright("Copyright © 2007-2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
@@ -38,6 +38,6 @@ using System.Resources;
 
 
 [assembly: AssemblyVersion("2.3.0.0")]
-[assembly: AssemblyFileVersion("2.3")]
-[assembly: AssemblyInformationalVersion("2.1")] // used in settings path, so be careful about changing
+[assembly: AssemblyFileVersion("2.3.0")]
+[assembly: AssemblyInformationalVersion("2.3 RC")]
 [assembly: NeutralResourcesLanguageAttribute("")]

--- a/TVRename#/TVRename/PathManager.cs
+++ b/TVRename#/TVRename/PathManager.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Alphaleonis.Win32.Filesystem;
 using FileInfo = Alphaleonis.Win32.Filesystem.FileInfo;
 
@@ -48,7 +48,7 @@ namespace TVRename
                 }
                 else
                 {
-                    return GetFileInfo(System.Windows.Forms.Application.UserAppDataPath, StatisticsFileName);
+                    return GetFileInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "TVRename", "TVRename", "2.1"), StatisticsFileName);
                 }
             }
         }
@@ -63,7 +63,7 @@ namespace TVRename
                 }
                 else
                 {
-                    return GetFileInfo(System.Windows.Forms.Application.UserAppDataPath, LayoutFileName);
+                    return GetFileInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "TVRename", "TVRename", "2.1"), LayoutFileName);
                 }
             }
         }
@@ -78,7 +78,7 @@ namespace TVRename
                 }
                 else
                 {
-                    return GetFileInfo(System.Windows.Forms.Application.UserAppDataPath, UILayoutFileName);
+                    return GetFileInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "TVRename", "TVRename", "2.1"), UILayoutFileName);
                 }
             }
         }
@@ -93,7 +93,7 @@ namespace TVRename
                 }
                 else
                 {
-                    return GetFileInfo(System.Windows.Forms.Application.UserAppDataPath, TVDBFileName);
+                    return GetFileInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "TVRename", "TVRename", "2.1"), TVDBFileName);
                 }
             }
         }
@@ -108,7 +108,7 @@ namespace TVRename
                 }
                 else
                 {
-                    return GetFileInfo(System.Windows.Forms.Application.UserAppDataPath, SettingsFileName);
+                    return GetFileInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "TVRename", "TVRename", "2.1"), SettingsFileName);
                 }
             }
         }


### PR DESCRIPTION
These changes address the version number issues discussed in #186 and #187. Without these changes it's very hard to do properly automated builds with full version numbers.

The version number the application displays is now returned from the binaries ``AssemblyInformationalVersion`` which Windows does not check for formatting. This allows us to display pretty version numbers like ``2.3 RC 1`` correctly.

Changing this attribute will effect ``Application.UserAppDataPath`` (``Roaming\TVRename\TVRename\2.1``) so I have hardcoded it for now.

Finally ``AssemblyInfo.cs`` can be updated with real version numbers. Note that these version numbers will only affect what you see during development; the deployment process will replace them at release time.