### PR TITLE
Correct uTorrent appdata path

### DIFF
--- a/TVRename#/Settings/Settings.cs
+++ b/TVRename#/Settings/Settings.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Main website for TVRename is http://tvrename.com
 // 
 // Source code available at http://code.google.com/p/tvrename/
@@ -712,7 +712,7 @@ namespace TVRename
 
             // ResumeDatPath
             FileInfo f2 =
-                new FileInfo(System.Windows.Forms.Application.UserAppDataPath + "\\..\\..\\..\\uTorrent\\resume.dat");
+                new FileInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"uTorrent\resume.dat"));
             this.ResumeDatPath = f2.Exists ? f2.FullName : "";
         }
 


### PR DESCRIPTION
This completes the move away from using ``Application.UserAppDataPath`` as per #202.