### PR TITLE
Set startup entrypoint

### DIFF
--- a/TVRename#/TVRename#.csproj
+++ b/TVRename#/TVRename#.csproj
@@ -55,6 +55,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject>GlobalMembersTVRename</StartupObject>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="AlphaFS, Version=2.1.0.0, Culture=neutral, PublicKeyToken=4d31a58f7d7ad5c9, processorArchitecture=MSIL">
       <HintPath>..\packages\AlphaFS.2.1.3\lib\net40\AlphaFS.dll</HintPath>


### PR DESCRIPTION
This sets the startup object in Visual Studio which can help speed up compilation as it doesn't need to search for the entrypoint.