### PR TITLE
Fix potential division by zero

### DIFF
--- a/TVRename#/TheTVDB/TheTVDB.cs
+++ b/TVRename#/TheTVDB/TheTVDB.cs
@@ -871,7 +871,8 @@ namespace TVRename
                     }
                 }
 
-                float percentDirty = 100 * totaldirty / totaleps;
+                float percentDirty = 100;
+                if (totaldirty > 0 || totaleps > 0) percentDirty = 100 * totaldirty / totaleps;
                 if ((totaleps>0) && ((percentDirty) >=10)) // 10%
                 {
                     kvp.Value.Dirty = true;


### PR DESCRIPTION
This fixes a division by zero exception due to the new ``percentDirty`` code. When performing a force refresh both ``totaldirty`` and ``totaleps`` can be zero.