### PR TITLE
Bugfix to address #385

### DIFF
--- a/TVRename#/TheTVDB/TheTVDB.cs
+++ b/TVRename#/TheTVDB/TheTVDB.cs
@@ -751,7 +751,7 @@ namespace TVRename
                     {
 
                         int id = (int) series["id"];
-                        int time = (int) series["lastUpdated"];
+                        long time = (long) series["lastUpdated"];
 
                         if (this.Series.ContainsKey(id)) // this is a series we have
                         {
@@ -816,7 +816,7 @@ namespace TVRename
                                 {
                                     foreach (JObject episodeData in response["data"])
                                     {
-                                        long serverUpdateTime = (int) episodeData["lastUpdated"];
+                                        long serverUpdateTime = (long) episodeData["lastUpdated"];
                                         int serverEpisodeId = (int) episodeData["id"];
 
                                         bool found = false;


### PR DESCRIPTION
Update cast from (int) to (long) to resolve overflow exception. Variable is declared as long, so cast should match it.
