### PR TITLE
Application Update Control 

### DIFF
--- a/TVRename/Forms/Preferences/Preferences.Designer.cs
+++ b/TVRename/Forms/Preferences/Preferences.Designer.cs
@@ -71,6 +71,7 @@ namespace TVRename
             this.label84 = new System.Windows.Forms.Label();
             this.lstMovieMonitorFolders = new System.Windows.Forms.ListBox();
             this.chkIncludeMoviesQuickRecent = new System.Windows.Forms.CheckBox();
+            this.tbCleanUpDownloadDirMoviesLength = new System.Windows.Forms.TextBox();
             this.colorDialog = new System.Windows.Forms.ColorDialog();
             this.cmDefaults = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.KODIToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -243,9 +244,12 @@ namespace TVRename
             this.bnMCPresets = new System.Windows.Forms.Button();
             this.pbMediaCenter = new System.Windows.Forms.PictureBox();
             this.tbFolderDeleting = new System.Windows.Forms.TabPage();
+            this.groupBox28 = new System.Windows.Forms.GroupBox();
+            this.cbCleanUpDownloadDirMoviesLength = new System.Windows.Forms.CheckBox();
+            this.cbCleanUpDownloadDirMovies = new System.Windows.Forms.CheckBox();
+            this.cbCleanUpDownloadDir = new System.Windows.Forms.CheckBox();
             this.label69 = new System.Windows.Forms.Label();
             this.cbDeleteShowFromDisk = new System.Windows.Forms.CheckBox();
-            this.cbCleanUpDownloadDir = new System.Windows.Forms.CheckBox();
             this.label32 = new System.Windows.Forms.Label();
             this.label30 = new System.Windows.Forms.Label();
             this.txtEmptyMaxSize = new System.Windows.Forms.TextBox();
@@ -473,10 +477,13 @@ namespace TVRename
             this.cbMissingXML = new System.Windows.Forms.CheckBox();
             this.cbMissingCSV = new System.Windows.Forms.CheckBox();
             this.txtMissingXML = new System.Windows.Forms.TextBox();
-            this.groupBox28 = new System.Windows.Forms.GroupBox();
-            this.cbCleanUpDownloadDirMovies = new System.Windows.Forms.CheckBox();
-            this.cbCleanUpDownloadDirMoviesLength = new System.Windows.Forms.CheckBox();
-            this.tbCleanUpDownloadDirMoviesLength = new System.Windows.Forms.TextBox();
+            this.tbAppUpdate = new System.Windows.Forms.TabPage();
+            this.chkUpdateCheckEnabled = new System.Windows.Forms.CheckBox();
+            this.grpUpdateIntervalOption = new System.Windows.Forms.GroupBox();
+            this.optUpdateCheckAlways = new System.Windows.Forms.RadioButton();
+            this.optUpdateCheckInterval = new System.Windows.Forms.RadioButton();
+            this.cboUpdateCheckInterval = new System.Windows.Forms.ComboBox();
+            this.chkNoPopupOnUpdate = new System.Windows.Forms.CheckBox();
             this.cmDefaults.SuspendLayout();
             this.tpDisplay.SuspendLayout();
             this.groupBox11.SuspendLayout();
@@ -507,6 +514,7 @@ namespace TVRename
             this.panel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pbMediaCenter)).BeginInit();
             this.tbFolderDeleting.SuspendLayout();
+            this.groupBox28.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pbFolderDeleting)).BeginInit();
             this.tbAutoExport.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox6)).BeginInit();
@@ -548,7 +556,8 @@ namespace TVRename
             this.groupBox7.SuspendLayout();
             this.groupBox27.SuspendLayout();
             this.groupBox3.SuspendLayout();
-            this.groupBox28.SuspendLayout();
+            this.tbAppUpdate.SuspendLayout();
+            this.grpUpdateIntervalOption.SuspendLayout();
             this.SuspendLayout();
             // 
             // OKButton
@@ -908,6 +917,14 @@ namespace TVRename
             this.chkIncludeMoviesQuickRecent.Text = "&Include Movies in Quick/Recent";
             this.toolTip1.SetToolTip(this.chkIncludeMoviesQuickRecent, "If checked the system will automatically scan and complete actions on startup");
             this.chkIncludeMoviesQuickRecent.UseVisualStyleBackColor = true;
+            // 
+            // tbCleanUpDownloadDirMoviesLength
+            // 
+            this.tbCleanUpDownloadDirMoviesLength.Location = new System.Drawing.Point(216, 65);
+            this.tbCleanUpDownloadDirMoviesLength.Name = "tbCleanUpDownloadDirMoviesLength";
+            this.tbCleanUpDownloadDirMoviesLength.Size = new System.Drawing.Size(55, 20);
+            this.tbCleanUpDownloadDirMoviesLength.TabIndex = 14;
+            this.toolTip1.SetToolTip(this.tbCleanUpDownloadDirMoviesLength, "Number of letters that the name of the movie must be. To prevent \'Up\' ");
             // 
             // cmDefaults
             // 
@@ -2846,6 +2863,51 @@ namespace TVRename
             this.tbFolderDeleting.Text = "Folder Deleting";
             this.tbFolderDeleting.UseVisualStyleBackColor = true;
             // 
+            // groupBox28
+            // 
+            this.groupBox28.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox28.Controls.Add(this.tbCleanUpDownloadDirMoviesLength);
+            this.groupBox28.Controls.Add(this.cbCleanUpDownloadDirMoviesLength);
+            this.groupBox28.Controls.Add(this.cbCleanUpDownloadDirMovies);
+            this.groupBox28.Controls.Add(this.cbCleanUpDownloadDir);
+            this.groupBox28.Location = new System.Drawing.Point(16, 242);
+            this.groupBox28.Name = "groupBox28";
+            this.groupBox28.Size = new System.Drawing.Size(395, 100);
+            this.groupBox28.TabIndex = 41;
+            this.groupBox28.TabStop = false;
+            this.groupBox28.Text = "Clean Up Search Folders";
+            // 
+            // cbCleanUpDownloadDirMoviesLength
+            // 
+            this.cbCleanUpDownloadDirMoviesLength.AutoSize = true;
+            this.cbCleanUpDownloadDirMoviesLength.Location = new System.Drawing.Point(45, 65);
+            this.cbCleanUpDownloadDirMoviesLength.Name = "cbCleanUpDownloadDirMoviesLength";
+            this.cbCleanUpDownloadDirMoviesLength.Size = new System.Drawing.Size(176, 17);
+            this.cbCleanUpDownloadDirMoviesLength.TabIndex = 13;
+            this.cbCleanUpDownloadDirMoviesLength.Text = "Only include movies longer than";
+            this.cbCleanUpDownloadDirMoviesLength.UseVisualStyleBackColor = true;
+            // 
+            // cbCleanUpDownloadDirMovies
+            // 
+            this.cbCleanUpDownloadDirMovies.AutoSize = true;
+            this.cbCleanUpDownloadDirMovies.Location = new System.Drawing.Point(6, 42);
+            this.cbCleanUpDownloadDirMovies.Name = "cbCleanUpDownloadDirMovies";
+            this.cbCleanUpDownloadDirMovies.Size = new System.Drawing.Size(284, 17);
+            this.cbCleanUpDownloadDirMovies.TabIndex = 12;
+            this.cbCleanUpDownloadDirMovies.Text = "Clean up already copied movie files from search folders";
+            this.cbCleanUpDownloadDirMovies.UseVisualStyleBackColor = true;
+            // 
+            // cbCleanUpDownloadDir
+            // 
+            this.cbCleanUpDownloadDir.AutoSize = true;
+            this.cbCleanUpDownloadDir.Location = new System.Drawing.Point(6, 19);
+            this.cbCleanUpDownloadDir.Name = "cbCleanUpDownloadDir";
+            this.cbCleanUpDownloadDir.Size = new System.Drawing.Size(293, 17);
+            this.cbCleanUpDownloadDir.TabIndex = 11;
+            this.cbCleanUpDownloadDir.Text = "Clean up already copied episode files from search folders";
+            this.cbCleanUpDownloadDir.UseVisualStyleBackColor = true;
+            // 
             // label69
             // 
             this.label69.AutoSize = true;
@@ -2865,16 +2927,6 @@ namespace TVRename
             this.cbDeleteShowFromDisk.TabIndex = 13;
             this.cbDeleteShowFromDisk.Text = "Ask to delete from disk when deleting show from database";
             this.cbDeleteShowFromDisk.UseVisualStyleBackColor = true;
-            // 
-            // cbCleanUpDownloadDir
-            // 
-            this.cbCleanUpDownloadDir.AutoSize = true;
-            this.cbCleanUpDownloadDir.Location = new System.Drawing.Point(6, 19);
-            this.cbCleanUpDownloadDir.Name = "cbCleanUpDownloadDir";
-            this.cbCleanUpDownloadDir.Size = new System.Drawing.Size(293, 17);
-            this.cbCleanUpDownloadDir.TabIndex = 11;
-            this.cbCleanUpDownloadDir.Text = "Clean up already copied episode files from search folders";
-            this.cbCleanUpDownloadDir.UseVisualStyleBackColor = true;
             // 
             // label32
             // 
@@ -3841,6 +3893,7 @@ namespace TVRename
             this.tcTabs.Controls.Add(this.tpJackett);
             this.tcTabs.Controls.Add(this.tbAutoExport);
             this.tcTabs.Controls.Add(this.tpAutoExportLibrary);
+            this.tcTabs.Controls.Add(this.tbAppUpdate);
             this.tcTabs.DrawMode = System.Windows.Forms.TabDrawMode.OwnerDrawFixed;
             this.tcTabs.ItemSize = new System.Drawing.Size(30, 135);
             this.tcTabs.Location = new System.Drawing.Point(12, 12);
@@ -5489,48 +5542,83 @@ namespace TVRename
             this.txtMissingXML.Size = new System.Drawing.Size(251, 20);
             this.txtMissingXML.TabIndex = 4;
             // 
-            // groupBox28
+            // tbAppUpdate
             // 
-            this.groupBox28.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBox28.Controls.Add(this.tbCleanUpDownloadDirMoviesLength);
-            this.groupBox28.Controls.Add(this.cbCleanUpDownloadDirMoviesLength);
-            this.groupBox28.Controls.Add(this.cbCleanUpDownloadDirMovies);
-            this.groupBox28.Controls.Add(this.cbCleanUpDownloadDir);
-            this.groupBox28.Location = new System.Drawing.Point(16, 242);
-            this.groupBox28.Name = "groupBox28";
-            this.groupBox28.Size = new System.Drawing.Size(395, 100);
-            this.groupBox28.TabIndex = 41;
-            this.groupBox28.TabStop = false;
-            this.groupBox28.Text = "Clean Up Search Folders";
+            this.tbAppUpdate.Controls.Add(this.grpUpdateIntervalOption);
+            this.tbAppUpdate.Controls.Add(this.chkUpdateCheckEnabled);
+            this.tbAppUpdate.Location = new System.Drawing.Point(139, 4);
+            this.tbAppUpdate.Name = "tbAppUpdate";
+            this.tbAppUpdate.Size = new System.Drawing.Size(417, 561);
+            this.tbAppUpdate.TabIndex = 20;
+            this.tbAppUpdate.Text = "App Updates";
+            this.tbAppUpdate.UseVisualStyleBackColor = true;
             // 
-            // cbCleanUpDownloadDirMovies
+            // chkUpdateCheckEnabled
             // 
-            this.cbCleanUpDownloadDirMovies.AutoSize = true;
-            this.cbCleanUpDownloadDirMovies.Location = new System.Drawing.Point(6, 42);
-            this.cbCleanUpDownloadDirMovies.Name = "cbCleanUpDownloadDirMovies";
-            this.cbCleanUpDownloadDirMovies.Size = new System.Drawing.Size(284, 17);
-            this.cbCleanUpDownloadDirMovies.TabIndex = 12;
-            this.cbCleanUpDownloadDirMovies.Text = "Clean up already copied movie files from search folders";
-            this.cbCleanUpDownloadDirMovies.UseVisualStyleBackColor = true;
+            this.chkUpdateCheckEnabled.AutoSize = true;
+            this.chkUpdateCheckEnabled.Location = new System.Drawing.Point(28, 22);
+            this.chkUpdateCheckEnabled.Name = "chkUpdateCheckEnabled";
+            this.chkUpdateCheckEnabled.Size = new System.Drawing.Size(115, 17);
+            this.chkUpdateCheckEnabled.TabIndex = 0;
+            this.chkUpdateCheckEnabled.Text = "Check for Updates";
+            this.chkUpdateCheckEnabled.UseVisualStyleBackColor = true;
+            this.chkUpdateCheckEnabled.CheckedChanged += new System.EventHandler(this.chkUpdateCheckEnabled_CheckedChanged);
             // 
-            // cbCleanUpDownloadDirMoviesLength
+            // grpUpdateIntervalOption
             // 
-            this.cbCleanUpDownloadDirMoviesLength.AutoSize = true;
-            this.cbCleanUpDownloadDirMoviesLength.Location = new System.Drawing.Point(45, 65);
-            this.cbCleanUpDownloadDirMoviesLength.Name = "cbCleanUpDownloadDirMoviesLength";
-            this.cbCleanUpDownloadDirMoviesLength.Size = new System.Drawing.Size(176, 17);
-            this.cbCleanUpDownloadDirMoviesLength.TabIndex = 13;
-            this.cbCleanUpDownloadDirMoviesLength.Text = "Only include movies longer than";
-            this.cbCleanUpDownloadDirMoviesLength.UseVisualStyleBackColor = true;
+            this.grpUpdateIntervalOption.Controls.Add(this.chkNoPopupOnUpdate);
+            this.grpUpdateIntervalOption.Controls.Add(this.cboUpdateCheckInterval);
+            this.grpUpdateIntervalOption.Controls.Add(this.optUpdateCheckInterval);
+            this.grpUpdateIntervalOption.Controls.Add(this.optUpdateCheckAlways);
+            this.grpUpdateIntervalOption.Location = new System.Drawing.Point(28, 56);
+            this.grpUpdateIntervalOption.Name = "grpUpdateIntervalOption";
+            this.grpUpdateIntervalOption.Size = new System.Drawing.Size(367, 135);
+            this.grpUpdateIntervalOption.TabIndex = 1;
+            this.grpUpdateIntervalOption.TabStop = false;
+            this.grpUpdateIntervalOption.Text = "Check for updates ...";
             // 
-            // tbCleanUpDownloadDirMoviesLength
+            // optUpdateCheckAlways
             // 
-            this.tbCleanUpDownloadDirMoviesLength.Location = new System.Drawing.Point(216, 65);
-            this.tbCleanUpDownloadDirMoviesLength.Name = "tbCleanUpDownloadDirMoviesLength";
-            this.tbCleanUpDownloadDirMoviesLength.Size = new System.Drawing.Size(55, 20);
-            this.tbCleanUpDownloadDirMoviesLength.TabIndex = 14;
-            this.toolTip1.SetToolTip(this.tbCleanUpDownloadDirMoviesLength, "Number of letters that the name of the movie must be. To prevent \'Up\' ");
+            this.optUpdateCheckAlways.AutoSize = true;
+            this.optUpdateCheckAlways.Location = new System.Drawing.Point(16, 20);
+            this.optUpdateCheckAlways.Name = "optUpdateCheckAlways";
+            this.optUpdateCheckAlways.Size = new System.Drawing.Size(89, 17);
+            this.optUpdateCheckAlways.TabIndex = 0;
+            this.optUpdateCheckAlways.TabStop = true;
+            this.optUpdateCheckAlways.Text = "on every start";
+            this.optUpdateCheckAlways.UseVisualStyleBackColor = true;
+            this.optUpdateCheckAlways.CheckedChanged += new System.EventHandler(this.updateCheckOption_CheckedChanged);
+            // 
+            // optUpdateCheckInterval
+            // 
+            this.optUpdateCheckInterval.AutoSize = true;
+            this.optUpdateCheckInterval.Location = new System.Drawing.Point(16, 44);
+            this.optUpdateCheckInterval.Name = "optUpdateCheckInterval";
+            this.optUpdateCheckInterval.Size = new System.Drawing.Size(111, 17);
+            this.optUpdateCheckInterval.TabIndex = 1;
+            this.optUpdateCheckInterval.TabStop = true;
+            this.optUpdateCheckInterval.Text = "at certain intervals";
+            this.optUpdateCheckInterval.UseVisualStyleBackColor = true;
+            this.optUpdateCheckInterval.CheckedChanged += new System.EventHandler(this.updateCheckOption_CheckedChanged);
+            // 
+            // cboUpdateCheckInterval
+            // 
+            this.cboUpdateCheckInterval.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cboUpdateCheckInterval.FormattingEnabled = true;
+            this.cboUpdateCheckInterval.Location = new System.Drawing.Point(16, 68);
+            this.cboUpdateCheckInterval.Name = "cboUpdateCheckInterval";
+            this.cboUpdateCheckInterval.Size = new System.Drawing.Size(166, 21);
+            this.cboUpdateCheckInterval.TabIndex = 2;
+            // 
+            // chkNoPopupOnUpdate
+            // 
+            this.chkNoPopupOnUpdate.AutoSize = true;
+            this.chkNoPopupOnUpdate.Location = new System.Drawing.Point(16, 112);
+            this.chkNoPopupOnUpdate.Name = "chkNoPopupOnUpdate";
+            this.chkNoPopupOnUpdate.Size = new System.Drawing.Size(169, 17);
+            this.chkNoPopupOnUpdate.TabIndex = 2;
+            this.chkNoPopupOnUpdate.Text = "No dialog on available Update";
+            this.chkNoPopupOnUpdate.UseVisualStyleBackColor = true;
             // 
             // Preferences
             // 
@@ -5607,6 +5695,8 @@ namespace TVRename
             ((System.ComponentModel.ISupportInitialize)(this.pbMediaCenter)).EndInit();
             this.tbFolderDeleting.ResumeLayout(false);
             this.tbFolderDeleting.PerformLayout();
+            this.groupBox28.ResumeLayout(false);
+            this.groupBox28.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pbFolderDeleting)).EndInit();
             this.tbAutoExport.ResumeLayout(false);
             this.tbAutoExport.PerformLayout();
@@ -5678,8 +5768,10 @@ namespace TVRename
             this.groupBox27.PerformLayout();
             this.groupBox3.ResumeLayout(false);
             this.groupBox3.PerformLayout();
-            this.groupBox28.ResumeLayout(false);
-            this.groupBox28.PerformLayout();
+            this.tbAppUpdate.ResumeLayout(false);
+            this.tbAppUpdate.PerformLayout();
+            this.grpUpdateIntervalOption.ResumeLayout(false);
+            this.grpUpdateIntervalOption.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -6123,5 +6215,12 @@ namespace TVRename
         private System.Windows.Forms.TextBox tbCleanUpDownloadDirMoviesLength;
         private System.Windows.Forms.CheckBox cbCleanUpDownloadDirMoviesLength;
         private System.Windows.Forms.CheckBox cbCleanUpDownloadDirMovies;
+        private System.Windows.Forms.TabPage tbAppUpdate;
+        private System.Windows.Forms.GroupBox grpUpdateIntervalOption;
+        private System.Windows.Forms.CheckBox chkNoPopupOnUpdate;
+        private System.Windows.Forms.ComboBox cboUpdateCheckInterval;
+        private System.Windows.Forms.RadioButton optUpdateCheckInterval;
+        private System.Windows.Forms.RadioButton optUpdateCheckAlways;
+        private System.Windows.Forms.CheckBox chkUpdateCheckEnabled;
     }
 }

--- a/TVRename/Forms/Preferences/Preferences.cs
+++ b/TVRename/Forms/Preferences/Preferences.cs
@@ -448,7 +448,7 @@ namespace TVRename
             s.DefMovieDoMissingCheck = cbDefMovieDoMissing.Checked;
             s.DefMovieUseutomaticFolders = cbDefMovieAutoFolders.Checked;
             s.DefMovieUseDefaultLocation = cbDefMovieUseDefLocation.Checked;
-            s.DefMovieDefaultLocation = cmbDefMovieLocation.SelectedItem.ToString();
+            s.DefMovieDefaultLocation = (string)cmbDefMovieLocation.SelectedItem;
             s.DefaultMovieProvider = MovieProviderMode();
 
             s.TMDBLanguage= cbTMDBLanguages.SelectedText;

--- a/TVRename/Forms/Preferences/Preferences.cs
+++ b/TVRename/Forms/Preferences/Preferences.cs
@@ -455,6 +455,30 @@ namespace TVRename
             s.TMDBRegion = cbTMDBRegions.SelectedText;
             s.TMDBPercentDirty = tbTMDBPercentDirty.Text.ToPercent(20);
             s.IncludeMoviesQuickRecent = chkIncludeMoviesQuickRecent.Checked;
+
+            UpdateAppUpdateSettings(s);
+        }
+
+        private void UpdateAppUpdateSettings(TVSettings s)
+        {
+            s.UpdateCheckType = GetUpdateCheckTypeFromUi();
+            if (cboUpdateCheckInterval.SelectedValue != null)
+            {
+                s.UpdateCheckInterval = (TimeSpan)cboUpdateCheckInterval.SelectedValue;
+            }
+            s.SuppressUpdateAvailablePopup = chkNoPopupOnUpdate.Checked;
+        }
+
+        private TVSettings.UpdateCheckMode GetUpdateCheckTypeFromUi()
+        {
+            if (chkUpdateCheckEnabled.Checked)
+            {
+                return optUpdateCheckAlways.Checked
+                    ? TVSettings.UpdateCheckMode.Everytime
+                    : TVSettings.UpdateCheckMode.Interval;
+            }
+
+            return TVSettings.UpdateCheckMode.Off;
         }
 
         private static TVSettings.DuplicateActionOutcome ConvertToDupActEnum([NotNull] ComboBox p0)
@@ -1031,9 +1055,73 @@ namespace TVRename
 
             FillTreeViewColoringShowStatusTypeCombobox();
 
+            SetupAppUpdateTabPageContent(s);
+
             EnableDisable();
         }
-        
+
+        private void SetupAppUpdateTabPageContent(TVSettings settings)
+        {
+            FillUpdateIntervals();
+            TriggerControlEventsForInitialState();
+
+            cboUpdateCheckInterval.SelectedValue = settings.UpdateCheckInterval;
+            chkNoPopupOnUpdate.Checked = settings.SuppressUpdateAvailablePopup;
+            SetUpdateCheckToTypeToUi(settings.UpdateCheckType);
+
+            void TriggerControlEventsForInitialState()
+            {
+                // These seem redundant but they are there to cycle the control events and get the controls into the correct enabled state
+                // The order of the statements additionally serves the purpose to set the default UI state
+                optUpdateCheckInterval.Checked = true;
+                optUpdateCheckAlways.Checked = true;
+                chkUpdateCheckEnabled.Checked = false;
+                chkUpdateCheckEnabled.Checked = true;
+            }
+        }
+
+        private void SetUpdateCheckToTypeToUi(TVSettings.UpdateCheckMode updateCheckMode)
+        {
+            switch (updateCheckMode)
+            {
+                case TVSettings.UpdateCheckMode.Off:
+                    chkUpdateCheckEnabled.Checked = false;
+                    break;
+                case TVSettings.UpdateCheckMode.Everytime:
+                    chkUpdateCheckEnabled.Checked = true;
+                    optUpdateCheckAlways.Checked = true;
+                    break;
+                case TVSettings.UpdateCheckMode.Interval:
+                    chkUpdateCheckEnabled.Checked = true;
+                    optUpdateCheckInterval.Checked = true;
+                    break;
+            }
+        }
+
+        private void FillUpdateIntervals()
+        {
+            cboUpdateCheckInterval.DisplayMember = nameof(UpdateCheckInterval.Text);
+            cboUpdateCheckInterval.ValueMember = nameof(UpdateCheckInterval.Interval);
+            cboUpdateCheckInterval.DataSource = new UpdateCheckInterval[]
+            {
+                new UpdateCheckInterval { Text = "1 Hour", Interval = TimeSpan.FromHours(1) },
+                new UpdateCheckInterval { Text = "12 Hours", Interval = TimeSpan.FromHours(12) },
+                new UpdateCheckInterval { Text = "1 Day", Interval = TimeSpan.FromHours(24) },
+                new UpdateCheckInterval { Text = "1 Week", Interval = TimeSpan.FromDays(7) },
+                new UpdateCheckInterval { Text = "2 Week", Interval = TimeSpan.FromDays(7 * 2) },
+                new UpdateCheckInterval { Text = "30 Days", Interval = TimeSpan.FromDays(30) },
+                new UpdateCheckInterval { Text = "90 Days", Interval = TimeSpan.FromDays(90) },
+
+            };
+        }
+
+        private class UpdateCheckInterval
+        {
+            public string Text { get; set; }
+
+            public TimeSpan Interval { get; set; }
+        }
+
         private void PopulateFromEnums([NotNull] TVSettings s)
         {
             cbKeepTogetherMode.Text = ConvertEnum(s.keepTogetherMode);
@@ -2126,6 +2214,16 @@ namespace TVRename
             cntfw = new CustomNameTagsFloatingWindow(t);
             cntfw.Show(this);
             Focus();
+        }
+
+        private void chkUpdateCheckEnabled_CheckedChanged(object sender, EventArgs e)
+        {
+            grpUpdateIntervalOption.Enabled = chkUpdateCheckEnabled.Checked;
+        }
+
+        private void updateCheckOption_CheckedChanged(object sender, EventArgs e)
+        {
+            cboUpdateCheckInterval.Enabled = optUpdateCheckInterval.Checked;
         }
     }
 }

--- a/TVRename/Settings/AppState/State.cs
+++ b/TVRename/Settings/AppState/State.cs
@@ -25,7 +25,6 @@ namespace TVRename.Settings.AppState
 
         public static State LoadFromFile(string path)
         {
-
             if (File.Exists(path))
             {
                 try

--- a/TVRename/Settings/AppState/State.cs
+++ b/TVRename/Settings/AppState/State.cs
@@ -1,0 +1,65 @@
+using NLog;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Serialization;
+using TVRename;
+using TVRename.Settings;
+using TVRename.Settings.AppState;
+
+namespace TVRename.Settings.AppState
+{
+    public class State
+    {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+        public UpdateCheck UpdateCheck { get; set; } = new UpdateCheck();
+
+        public static State LoadFromDefaultFile()
+        {
+            return LoadFromFile(PathManager.StateFile.FullName);
+        }
+
+        public static State LoadFromFile(string path)
+        {
+
+            if (File.Exists(path))
+            {
+                try
+                {
+                    var serializer = new XmlSerializer(typeof(State));
+                    using (var reader = XmlReader.Create(path))
+                    {
+                        return (State)serializer.Deserialize(reader);
+                    }
+                }
+                catch(Exception ex)
+                {
+                    Logger.Warn(ex, "Could not load app state file {0}", path);
+                    return new State();
+                }
+            }
+
+            return new State();
+        }
+
+        public void SaveToDefaultFile()
+        {
+            SaveToFile(PathManager.StateFile.FullName);
+        }
+
+        public void SaveToFile(string path)
+        {
+            var serializer = new XmlSerializer(typeof(State));
+            XmlWriterSettings xmlWriterSettings = new XmlWriterSettings();
+            xmlWriterSettings.Indent = true;
+            using (var xmlWriter = System.Xml.XmlWriter.Create(path, xmlWriterSettings))
+            {
+                serializer.Serialize(xmlWriter, this);
+            }
+        }
+    }
+}

--- a/TVRename/Settings/AppState/UpdateCheck.cs
+++ b/TVRename/Settings/AppState/UpdateCheck.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace TVRename.Settings.AppState
+{
+    public class UpdateCheck
+    {
+        public DateTime? LastUpdateCheckUtc { get; set; }
+
+        // This state can be extended when we want to provide a "skip this version" feature etc.
+
+        [XmlIgnore]
+        public TimeSpan LastUpdate => DateTime.UtcNow - LastUpdateCheckUtc.GetValueOrDefault(DateTime.MinValue);
+    }
+}

--- a/TVRename/Settings/Settings.cs
+++ b/TVRename/Settings/Settings.cs
@@ -407,7 +407,6 @@ namespace TVRename
         public string? DefMovieDefaultLocation;
         public TVDoc.ProviderType DefaultMovieProvider = TVDoc.ProviderType.TMDB;
 
-
         private TVSettings()
         {
             // defaults that aren't handled with default initialisers
@@ -738,7 +737,6 @@ namespace TVRename
             }
 
             writer.WriteEndElement(); //ShowFilters
-
 
             writer.WriteStartElement("MovieFilters");
 
@@ -1618,7 +1616,6 @@ namespace TVRename
             {
                 MovieFilter.Genres.Add(rep.Value);
             }
-
 
             if (SeasonFolderFormat == string.Empty)
             {

--- a/TVRename/TVRename.csproj
+++ b/TVRename/TVRename.csproj
@@ -454,9 +454,11 @@
     </Compile>
     <Compile Include="ScanActivity\ScanShowActivity\CheckAllMovieFoldersExist.cs" />
     <Compile Include="ScanActivity\ScanShowActivity\RenameAndMissingMovieCheck.cs" />
+    <Compile Include="Settings\AppState\UpdateCheck.cs" />
     <Compile Include="Settings\MovieConfiguration.cs" />
     <Compile Include="Settings\MovieFilter.cs" />
     <Compile Include="Settings\PreviouslySeenMovies.cs" />
+    <Compile Include="Settings\AppState\State.cs" />
     <Compile Include="Sources\SourceConsistencyException.cs" />
     <Compile Include="Sources\TheTVDB\TvdbAccuracyCheck.cs" />
     <Compile Include="Sources\TMDB\LocalCache.cs" />

--- a/TVRename/TVRename/PathManager.cs
+++ b/TVRename/TVRename/PathManager.cs
@@ -21,6 +21,7 @@ namespace TVRename
         private const string UI_LAYOUT_FILE_NAME = "Layout.xml";
         private const string STATISTICS_FILE_NAME = "Statistics.xml";
         private const string LANGUAGES_FILE_NAME = "Languages.xml";
+        private const string STATE_FILE_NAME = "State.xml";
 
         private static string UserDefinedBasePath;
 
@@ -58,6 +59,8 @@ namespace TVRename
             Directory.CreateDirectory(path);
             return new FileInfo(System.IO.Path.Combine(path, file));
         }
+
+        public static FileInfo StateFile => GetFileInfo(STATE_FILE_NAME);
 
         [NotNull]
         public static FileInfo StatisticsFile => GetFileInfo(STATISTICS_FILE_NAME);

--- a/TVRename/TVRename/TVDoc.cs
+++ b/TVRename/TVRename/TVDoc.cs
@@ -26,6 +26,7 @@ using Directory = Alphaleonis.Win32.Filesystem.Directory;
 using DirectoryInfo = Alphaleonis.Win32.Filesystem.DirectoryInfo;
 using File = Alphaleonis.Win32.Filesystem.File;
 using FileInfo = Alphaleonis.Win32.Filesystem.FileInfo;
+using TVRename.Settings.AppState;
 
 namespace TVRename
 {
@@ -48,6 +49,7 @@ namespace TVRename
         public readonly MovieLibrary FilmLibrary;
         public readonly CommandLineArgs Args;
         internal readonly TVRenameStats CurrentStats;
+        internal readonly State CurrentAppState;
         public readonly ItemList TheActionList;
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
         private readonly ActionEngine actionManager;
@@ -102,6 +104,16 @@ namespace TVRename
             {
                 CurrentStats = new TVRenameStats();
                 // not worried if stats loading fails
+            }
+
+            try
+            {
+                CurrentAppState = State.LoadFromDefaultFile();
+            }
+            catch(Exception ex)
+            {
+                Logger.Warn(ex, "Could not load app state file.");
+                CurrentAppState = new State();
             }
             actionManager = new ActionEngine(CurrentStats);
         }


### PR DESCRIPTION
This feature gives the user a greater control about the "Application Update Check"-
It allows:
- Disabling checking for updates entirely
- Checking for Updates in predefined intervals (daily, every 12 hours, etc.)
- Disabling the "Update available" popup on start (while still indicating available updates via the toolbar indication)
