### PR TITLE
Publishprofile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 /TVRename/obj
 /TVRename/bin
 /TVRename/publish
-*.user

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /packages
 /TVRename/obj
 /TVRename/bin
+/TVRename/publish
+*.user

--- a/TVRename/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/TVRename/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>publish\net6.0-windows</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishReadyToRun>false</PublishReadyToRun>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
#926 added publishprofile to output with all dependencies from .NET. Should mean it isn't necessary to install .NET on target machines in future.