### PR TITLE
Fixes to include published version of build artifacts in installer

### DIFF
--- a/Installer.nsi
+++ b/Installer.nsi
@@ -55,12 +55,12 @@ Section "Install"
 
     Delete "$INSTDIR\Ionic.Utils.Zip.dll" ; Remove old dependency
 
-    File "TVRename\bin\Release\net6.0-windows\TVRename.exe"
-    File "TVRename\bin\Release\net6.0-windows\*.dll"
-    File "TVRename\bin\Release\net6.0-windows\*.json"
-    File "TVRename\bin\Release\net6.0-windows\TVRename.dll.config"
+    File "TVRename\publish\net6.0-windows\TVRename.exe"
+    File "TVRename\publish\net6.0-windows\*.dll"
+    File "TVRename\publish\net6.0-windows\*.json"
+    File "TVRename\publish\net6.0-windows\TVRename.dll.config"
     
-    File "TVRename\bin\Release\net6.0-windows\NLog.config"
+    File "TVRename\publish\net6.0-windows\NLog.config"
 
     WriteUninstaller "$INSTDIR\Uninstall.exe"
 

--- a/TVRename/msbuild.rsp
+++ b/TVRename/msbuild.rsp
@@ -1,0 +1,3 @@
+/p:configuration=Release
+/t:Publish
+/p:PublishProfile=./Properties/PublishProfiles/FolderProfile.pubxml


### PR DESCRIPTION
#965, fixes for:

- added publish command line arg to msbuild.rsp
- corrected binary pull dir in nsis script

(if you can see them, ignore commits from May 29. was noob-ishly messing about trying to figure out how to make a PR. all changes reverted.)