### PR TITLE
Fix for interactive scan + MediaMetaData slowness

### DIFF
--- a/TVRename/ScanActivity/CleanDownloadDirectory.cs
+++ b/TVRename/ScanActivity/CleanDownloadDirectory.cs
@@ -438,7 +438,7 @@ internal class CleanDownloadDirectory : ScanActivity
 
             case FileHelper.VideoComparison.cantTell:
             case FileHelper.VideoComparison.similar:
-                if (unattended)
+                if (unattended || (!TVSettings.Instance.ReplaceWithBetterQuality && !TVSettings.Instance.ChooseWhenMultipleEpisodesMatch))
                 {
                     LOGGER.Info(
                         $"Keeping {newFile.FullName} as it might be better quality than {existingFile.FullName}");
@@ -507,7 +507,7 @@ internal class CleanDownloadDirectory : ScanActivity
 
             case FileHelper.VideoComparison.cantTell:
             case FileHelper.VideoComparison.similar:
-                if (unattended)
+                if (unattended || !TVSettings.Instance.ReplaceMoviesWithBetterQuality)
                 {
                     LOGGER.Info(
                         $"Keeping {newFile.FullName} as it might be better quality than {existingFile.FullName}");

--- a/TVRename/ScanActivity/DownloadIdentifers/DownloadIdentifiersController.cs
+++ b/TVRename/ScanActivity/DownloadIdentifers/DownloadIdentifiersController.cs
@@ -35,7 +35,7 @@ internal class DownloadIdentifiersController
             new DownloadKodiMetaData(),
             new DownloadKodiImages(),
             new IncorrectFileDates(),
-            new MediaMetaData(),
+            //new MediaMetaData(), //Disabled due to extensive additional time to scan folder and no settings to disable it
         ];
     }
 


### PR DESCRIPTION
This fixes interactive scan bug that I reported: https://github.com/TV-Rename/tvrename/issues/1016
The mediametadata issue is just because it made the scan process excruciatingly slow on large libraries and there is no setting to disable the process. 